### PR TITLE
fix: now the show details is not visible if no changes are made (moving position in array field)

### DIFF
--- a/src/components/IconManagerDiffComponent/IconDiffChangeList.tsx
+++ b/src/components/IconManagerDiffComponent/IconDiffChangeList.tsx
@@ -10,7 +10,8 @@ const IconDiffChangeList = (props: DiffProps<ObjectDiff<IconManagerType>>) => {
     setIsDetailsOpen((state) => !state)
   }, [setIsDetailsOpen])
 
-  if (!props.diff.fromValue?.icon && !props.diff.toValue?.icon) return null
+  if (!props.diff.isChanged || (!props.diff.fromValue?.icon && !props.diff.toValue?.icon))
+    return null
 
   return (
     <>


### PR DESCRIPTION
The show details cta is not visible anymore when you change only icon position in an array field.